### PR TITLE
Update Chassis Elasticsearch module reference

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -2,7 +2,7 @@ version: 2
 dependencies:
   - Chassis/phpdbg
   - shadyvb/chassis-redis
-  - Chassis/Chassis-Elasticsearch
+  - Chassis/Chassis_Elasticsearch
   - Chassis/v8js
   - Chassis/Tachyon
   - Chassis/intl


### PR DESCRIPTION
This extension has been renamed as part of work to support the newer Ubuntu LTS release. We need to update the name we use to clone the project, or provisioning fails.

The other extensions on this list have yet to be updated to use underscores instead of dashes, so this is the only change we can make at this time.