### PR TITLE
Add yarn as a dependency

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -14,3 +14,4 @@ dependencies:
   - Chassis/Mailhog
   - humanmade/chassis_aws_analytics
   - Chassis/Imagick
+  - Chassis/yarn


### PR DESCRIPTION
Until upstream Chassis has a solution for recursively installing extension dependencies this is a quick fix for the time being.