### PR TITLE
Add xhprof

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -15,3 +15,4 @@ dependencies:
   - humanmade/chassis_aws_analytics
   - Chassis/Imagick
   - Chassis/yarn
+  - Chassis/xhprof


### PR DESCRIPTION
For Altis V3 we're using XRay locally too in Query Monitor.

Fixes humanmade/altis-local-chassis#47