### PR TITLE
Support altis nginx-additions*.conf

### DIFF
--- a/modules/platform_chassis_extension/manifests/init.pp
+++ b/modules/platform_chassis_extension/manifests/init.pp
@@ -2,5 +2,11 @@
 class platform_chassis_extension(
   $config
 ) {
-	# Empty, just here as a meta-package.
+	# Add an nginx config file that includes .config/nginx-additions*.conf
+	file { "/etc/nginx/sites-available/${fqdn}.d/altis-additions.nginx.conf":
+		ensure  => present,
+		content => template('platform_chassis_extension/nginx.conf'),
+		notify  => Service['nginx'],
+		require => File["/etc/nginx/sites-available/${fqdn}.d"],
+	}
 }

--- a/modules/platform_chassis_extension/manifests/init.pp
+++ b/modules/platform_chassis_extension/manifests/init.pp
@@ -5,7 +5,7 @@ class platform_chassis_extension(
 	# Add an nginx config file that includes .config/nginx-additions*.conf
 	file { "/etc/nginx/sites-available/${fqdn}.d/altis-additions.nginx.conf":
 		ensure  => present,
-		content => template('platform_chassis_extension/nginx.conf'),
+		content => 'include /chassis/.config/nginx-additions*.conf;',
 		notify  => Service['nginx'],
 		require => File["/etc/nginx/sites-available/${fqdn}.d"],
 	}

--- a/modules/platform_chassis_extension/templates/nginx.conf
+++ b/modules/platform_chassis_extension/templates/nginx.conf
@@ -1,0 +1,2 @@
+# Load custom nginx rules for project.
+include /chassis/.config/nginx-additions*.conf;

--- a/modules/platform_chassis_extension/templates/nginx.conf
+++ b/modules/platform_chassis_extension/templates/nginx.conf
@@ -1,2 +1,0 @@
-# Load custom nginx rules for project.
-include /chassis/.config/nginx-additions*.conf;


### PR DESCRIPTION
Adds local support for `.config/nginx-additions*.conf` in accordance with local server and production stacks.