### PR TITLE
Replace shadyvb/chassis-redis with Chassis/redis in the extension dependencies

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -1,7 +1,7 @@
 version: 2
 dependencies:
   - Chassis/phpdbg
-  - shadyvb/chassis-redis
+  - Chassis/chassis-redis
   - Chassis/Chassis_Elasticsearch
   - Chassis/v8js
   - Chassis/Tachyon

--- a/chassis.yaml
+++ b/chassis.yaml
@@ -1,7 +1,7 @@
 version: 2
 dependencies:
   - Chassis/phpdbg
-  - Chassis/chassis-redis
+  - Chassis/redis
   - Chassis/Chassis_Elasticsearch
   - Chassis/v8js
   - Chassis/Tachyon


### PR DESCRIPTION
`shadyvb/chassis-redis` is outdated and archived by the author, and with current versions of Chassis it fails. `Chassis/redis` works with recent versions of Chassis and with Chassis/redis#9 will install everything successfully.